### PR TITLE
Small performance improvement in intersection step

### DIFF
--- a/src/main/java/net/scottjulian/lcs/DirectedAcyclicGraph.java
+++ b/src/main/java/net/scottjulian/lcs/DirectedAcyclicGraph.java
@@ -47,6 +47,9 @@ public class DirectedAcyclicGraph {
                     if(_sequences[k].containsPair(currentPair)) {
                         count++;
                     }
+                    else {
+                        break;
+                    }
                 }
                 if(count == numOfSeqs){
                     Boolean contains = false;


### PR DESCRIPTION
Hi, I'm still trying to understand how do you see the intersection pairs as an DAG, but while I was running your code, I've noticed this small improvement opportunity. If one pair doesn't exist in one sequence, there is no need to check for it in the others sequences.
Please, let me know if I'm wrong and feel free to discard this PR or make it in your own way. It's your code, I just made this, to show to you.

Good algorithm, and thanks for share it.